### PR TITLE
"node app.js --harmony"命令出错

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ koa 依赖支持 generator 的 Node 环境，准确来说，是 `node >= 0.11.9`
 $ npm install koa
 ````
 
-安装完成后，应确保使用 `$ node app.js --harmony` 即，harmony 模式运行程序。
+安装完成后，应确保使用 `$ node --harmony app.js` 即，harmony 模式运行程序。
 
 为了方便，可以将 `node` 设置为默认启动 harmony 模式的别名：
 


### PR DESCRIPTION
环境：node 0.11.13

如果使用"node app.js --harmony" 来运行第一个 “Hello World” 示例，则会报错。此命令应该将 --harmony 提前才行。

![14 pic](https://cloud.githubusercontent.com/assets/1147941/3281413/e321c124-f4a9-11e3-822d-b1ed017b4b35.jpg)
